### PR TITLE
feat: track the V4 markets' ACLManager and PoolAddressesProvider

### DIFF
--- a/helpers/configs/networks/arc.ts
+++ b/helpers/configs/networks/arc.ts
@@ -26,11 +26,14 @@ for (const [key, address] of Object.entries(deduplicatedV4Addresses)) {
 
 const aaveV4 = createV4({
   accessManagerBlock: 18791458,
+  aclBlock: 17408596,
   tokenizationSpokesAddressBook: v4TokenizationSpokesAddressBook,
   addressBook: {
     ACCESS_MANAGER: AaveV4Arc.ACCESS_MANAGER,
     HUB_CONFIGURATOR: AaveV4Arc.HUB_CONFIGURATOR,
     SPOKE_CONFIGURATOR: AaveV4Arc.SPOKE_CONFIGURATOR,
+    POOL_ADDRESSES_PROVIDER: MiscArc.POOL_ADDRESSES_PROVIDER,
+    ACL_MANAGER: MiscArc.ACL_MANAGER,
     ...v4MainAddressBook,
     ...(AaveV4Arc.POSITION_MANAGERS as Record<string, string>),
   },

--- a/helpers/configs/networks/avalanche.ts
+++ b/helpers/configs/networks/avalanche.ts
@@ -63,6 +63,9 @@ const aaveV4 = createV4({
     ACCESS_MANAGER: AaveV4Avalanche.ACCESS_MANAGER,
     HUB_CONFIGURATOR: AaveV4Avalanche.HUB_CONFIGURATOR,
     SPOKE_CONFIGURATOR: AaveV4Avalanche.SPOKE_CONFIGURATOR,
+    // Shared with the V3 market, so no aclBlock: the V3 pool indexes it
+    POOL_ADDRESSES_PROVIDER: AaveV3Avalanche.POOL_ADDRESSES_PROVIDER,
+    ACL_MANAGER: AaveV3Avalanche.ACL_MANAGER,
     ...v4MainAddressBook,
     ...(AaveV4Avalanche.POSITION_MANAGERS as Record<string, string>),
   },

--- a/helpers/configs/networks/mainnet.ts
+++ b/helpers/configs/networks/mainnet.ts
@@ -142,6 +142,9 @@ const aaveV4 = createV4({
     ACCESS_MANAGER: AaveV4Ethereum.ACCESS_MANAGER,
     HUB_CONFIGURATOR: AaveV4Ethereum.HUB_CONFIGURATOR,
     SPOKE_CONFIGURATOR: AaveV4Ethereum.SPOKE_CONFIGURATOR,
+    // Shared with the V3 market, so no aclBlock: the V3 pool indexes it
+    POOL_ADDRESSES_PROVIDER: AaveV3Ethereum.POOL_ADDRESSES_PROVIDER,
+    ACL_MANAGER: AaveV3Ethereum.ACL_MANAGER,
     ...v4MainAddressBook,
     ...(AaveV4Ethereum.POSITION_MANAGERS as Record<string, string>),
   },

--- a/helpers/configs/poolBuilder.ts
+++ b/helpers/configs/poolBuilder.ts
@@ -12,6 +12,8 @@ export interface V4Config {
   addressBook: AddressBook;
   roleLabels?: Record<string, string>;
   tokenizationSpokesAddressBook?: Record<string, string>;
+  /** ACLManager deployment block, when the market has a V3-style ACL periphery */
+  aclBlock?: number;
 }
 
 /**

--- a/out/ARC-V4.md
+++ b/out/ARC-V4.md
@@ -9,6 +9,8 @@
 |  [FOREX Spoke](https://explorer.arc.io/address/0x4164EBCAF74670aa74C8D4F59de6157c0780F1bB) |  V4 Security Council | |--------|--------|
 |  [SpokeConfigurator](https://explorer.arc.io/address/0x102610d2A7Fd87A85ad8fdCfC78879be8Fd40576) |  not upgradeable | |--------|--------|
 |  [TreasurySpoke](https://explorer.arc.io/address/0xcbd466CB8709D9f6dd8312668B4dbef394cE0e15) |  V4 Security Council | |--------|--------|
+|  [PoolAddressesProvider](https://explorer.arc.io/address/0xf74284E5aeDC3AD57CD2Fa2461bf2E1762422a12) |  not upgradeable | |--------|--------|
+|  [ACLManager](https://explorer.arc.io/address/0x4d4B307857eFff79E786923F2A277ea298E88aEA) |  not upgradeable | |--------|--------|
 
 ### TokenizationSpokes upgradeability
 | contract |upgradeable by |
@@ -17,6 +19,12 @@
 |  [CORE EURC TokenizationSpoke](https://explorer.arc.io/address/0x5A10b1533C0f1f181DC8a428BF5Eb58B08fc8d2c) |  V4 Security Council | |--------|--------|
 |  [CORE cirBTC TokenizationSpoke](https://explorer.arc.io/address/0x83D364DbAf4e7018E0b87dB3FaB3d1d8535a6F13) |  V4 Security Council | |--------|--------|
 |  [CORE WETH TokenizationSpoke](https://explorer.arc.io/address/0xe8B890fea6e1E3915A337eD3136487F2f4f7e59D) |  V4 Security Council | |--------|--------|
+
+### Actions type
+| type |can be executed by |
+|----------|----------|
+|  adminsConfiguration |  Multi-sig | |--------|--------|
+|  protocolUpgradeablity |  Multi-sig | |--------|--------|
 
 ### Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |
@@ -31,6 +39,8 @@
 |  [FOREX Spoke](https://explorer.arc.io/address/0x4164EBCAF74670aa74C8D4F59de6157c0780F1bB) |  [FOREX Spoke ProxyAdmin](https://explorer.arc.io/address/0xE8d75bb46C15c70dB2A464886f51b8a46A871108) |  SPOKE_USER_POSITION_UPDATER_ROLE |  [V4 Security Council](https://explorer.arc.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  updateUserDynamicConfig, updateUserRiskPremium | |--------|--------|--------|--------|--------|
 |  [SpokeConfigurator](https://explorer.arc.io/address/0x102610d2A7Fd87A85ad8fdCfC78879be8Fd40576) |  - |  SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE |  [V4 Security Council Executor](https://explorer.arc.io/address/0x8e79b0541122d3822eC93082cEB1ab03EDBc1Fd5) |  updateReservePriceSource, updateLiquidationTargetHealthFactor, updateHealthFactorForMaxBonus, updateLiquidationBonusFactor, updateLiquidationConfig, addReserve, updatePaused, updateFrozen, updateBorrowable, updateReceiveSharesEnabled, updateCollateralRisk, addCollateralFactor, updateCollateralFactor, addMaxLiquidationBonus, updateMaxLiquidationBonus, addLiquidationFee, updateLiquidationFee, addDynamicReserveConfig, updateDynamicReserveConfig, pauseAllReserves, freezeAllReserves, pauseReserve, freezeReserve, updatePositionManager | |--------|--------|--------|--------|--------|
 |  [TreasurySpoke](https://explorer.arc.io/address/0xcbd466CB8709D9f6dd8312668B4dbef394cE0e15) |  [TreasurySpoke ProxyAdmin](https://explorer.arc.io/address/0xfa12D100A649c8D4dCC0047f9618b2bB4939f6A0) |  onlyOwner |  [V4 Security Council](https://explorer.arc.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  supply, supplySkimmed, withdraw, transfer | |--------|--------|--------|--------|--------|
+|  [PoolAddressesProvider](https://explorer.arc.io/address/0xf74284E5aeDC3AD57CD2Fa2461bf2E1762422a12) |  - |  onlyOwner |  [V4 Security Council](https://explorer.arc.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  setMarketId, setAddress, setAddressAsProxy, setPoolImpl, setPoolConfiguratorImpl, setPriceOracle, setACLManager, setACLAdmin, setPriceOracleSentinel, setPoolDataProvider | |--------|--------|--------|--------|--------|
+|  [ACLManager](https://explorer.arc.io/address/0x4d4B307857eFff79E786923F2A277ea298E88aEA) |  - |  onlyRole |  [V4 Security Council](https://explorer.arc.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  setRoleAdmin | |--------|--------|--------|--------|--------|
 
 ### PositionManagers Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |
@@ -50,6 +60,16 @@
 | Guardian |Threshold |Address |Owners |
 |----------|----------|----------|----------|
 |  [V4 Security Council](https://explorer.arc.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  5/8 |  0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9 |  [0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF](https://explorer.arc.io/address/0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF), [0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749](https://explorer.arc.io/address/0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749), [0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065](https://explorer.arc.io/address/0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065), [0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884](https://explorer.arc.io/address/0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884), [0x75C26ED4D9c5D331665766394D933E12f8597a55](https://explorer.arc.io/address/0x75C26ED4D9c5D331665766394D933E12f8597a55), [0x9440850335c7C2a644dc2abEBBA93463c9736F2C](https://explorer.arc.io/address/0x9440850335c7C2a644dc2abEBBA93463c9736F2C), [0xbf113Fa52454A94185b65e6f2E818B7f178f937a](https://explorer.arc.io/address/0xbf113Fa52454A94185b65e6f2E818B7f178f937a), [0x606dC57cd166643760E049609bfd1D8a698D3bAc](https://explorer.arc.io/address/0x606dC57cd166643760E049609bfd1D8a698D3bAc) | |--------|--------|--------|--------|
+
+### Admins
+| Role |Contract |
+|----------|----------|
+|  DEFAULT_ADMIN |  [V4 Security Council](https://explorer.arc.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) | |--------|--------|
+|  ASSET_LISTING_ADMIN |   | |--------|--------|
+|  EMERGENCY_ADMIN |   | |--------|--------|
+|  FLASH_BORROWER |   | |--------|--------|
+|  POOL_ADMIN |   | |--------|--------|
+|  RISK_ADMIN |   | |--------|--------|
 
 ### AccessManager Roles
 | Role |Contract |

--- a/out/AVALANCHE-V4.md
+++ b/out/AVALANCHE-V4.md
@@ -10,6 +10,8 @@
 |  [AVAX CORRELATED Spoke](https://snowscan.xyz/address/0x3b517594277c67307CF2d7CBE6FE1D4399B68c41) |  V4 Security Council | |--------|--------|
 |  [SpokeConfigurator](https://snowscan.xyz/address/0x8F72573F1Aa0A1e39fFD2a2A69e9EDAa8B982642) |  not upgradeable | |--------|--------|
 |  [TreasurySpoke](https://snowscan.xyz/address/0x2C4Aea1A5F000889c6DfFE8f52377aFc2CB113a6) |  V4 Security Council | |--------|--------|
+|  [PoolAddressesProvider](https://snowscan.xyz/address/0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb) |  not upgradeable | |--------|--------|
+|  [ACLManager](https://snowscan.xyz/address/0xa72636CbcAa8F5FF95B2cc47F3CDEe83F3294a0B) |  not upgradeable | |--------|--------|
 
 ### TokenizationSpokes upgradeability
 | contract |upgradeable by |
@@ -21,6 +23,12 @@
 |  [CORE WETHe TokenizationSpoke](https://snowscan.xyz/address/0xF5c849468318c8D5670020fdb96ae135FED37070) |  V4 Security Council | |--------|--------|
 |  [CORE EURC TokenizationSpoke](https://snowscan.xyz/address/0x7b538a1840EAf2Ed92EEB67eE744AE627335e201) |  V4 Security Council | |--------|--------|
 |  [CORE sAVAX TokenizationSpoke](https://snowscan.xyz/address/0x6c27A7435040B7cC512319d5690BeEF234dfE76e) |  V4 Security Council | |--------|--------|
+
+### Actions type
+| type |can be executed by |
+|----------|----------|
+|  adminsConfiguration |  Governance | |--------|--------|
+|  protocolUpgradeablity |  Governance | |--------|--------|
 
 ### Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |
@@ -37,6 +45,8 @@
 |  [AVAX CORRELATED Spoke](https://snowscan.xyz/address/0x3b517594277c67307CF2d7CBE6FE1D4399B68c41) |  [AVAX CORRELATED Spoke ProxyAdmin](https://snowscan.xyz/address/0x34F5392e2CFEDf971223f070d3c51BD5165196F4) |  SPOKE_USER_POSITION_UPDATER_ROLE |   |  updateUserDynamicConfig, updateUserRiskPremium | |--------|--------|--------|--------|--------|
 |  [SpokeConfigurator](https://snowscan.xyz/address/0x8F72573F1Aa0A1e39fFD2a2A69e9EDAa8B982642) |  - |  SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE |  [V4 Security Council Executor](https://snowscan.xyz/address/0xb619fA61e795D47f517702e63ce50292370561F1) |  updateReservePriceSource, updateLiquidationTargetHealthFactor, updateHealthFactorForMaxBonus, updateLiquidationBonusFactor, updateLiquidationConfig, addReserve, updatePaused, updateFrozen, updateBorrowable, updateReceiveSharesEnabled, updateCollateralRisk, addCollateralFactor, updateCollateralFactor, addMaxLiquidationBonus, updateMaxLiquidationBonus, addLiquidationFee, updateLiquidationFee, addDynamicReserveConfig, updateDynamicReserveConfig, pauseAllReserves, freezeAllReserves, pauseReserve, freezeReserve, updatePositionManager | |--------|--------|--------|--------|--------|
 |  [TreasurySpoke](https://snowscan.xyz/address/0x2C4Aea1A5F000889c6DfFE8f52377aFc2CB113a6) |  [TreasurySpoke ProxyAdmin](https://snowscan.xyz/address/0x0b448c233298d33B163D877aC43bF8Fa884480e1) |  onlyOwner |  [V4 Security Council](https://snowscan.xyz/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  supply, supplySkimmed, withdraw, transfer | |--------|--------|--------|--------|--------|
+|  [PoolAddressesProvider](https://snowscan.xyz/address/0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb) |  - |  onlyOwner |  [Executor_lvl1](https://snowscan.xyz/address/0x3C06dce358add17aAf230f2234bCCC4afd50d090) |  setMarketId, setAddress, setAddressAsProxy, setPoolImpl, setPoolConfiguratorImpl, setPriceOracle, setACLManager, setACLAdmin, setPriceOracleSentinel, setPoolDataProvider | |--------|--------|--------|--------|--------|
+|  [ACLManager](https://snowscan.xyz/address/0xa72636CbcAa8F5FF95B2cc47F3CDEe83F3294a0B) |  - |  onlyRole |  [Executor_lvl1](https://snowscan.xyz/address/0x3C06dce358add17aAf230f2234bCCC4afd50d090) |  setRoleAdmin | |--------|--------|--------|--------|--------|
 
 ### PositionManagers Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |
@@ -58,6 +68,16 @@
 | Guardian |Threshold |Address |Owners |
 |----------|----------|----------|----------|
 |  [V4 Security Council](https://snowscan.xyz/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  5/8 |  0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9 |  [0x9440850335c7C2a644dc2abEBBA93463c9736F2C](https://snowscan.xyz/address/0x9440850335c7C2a644dc2abEBBA93463c9736F2C), [0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF](https://snowscan.xyz/address/0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF), [0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749](https://snowscan.xyz/address/0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749), [0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065](https://snowscan.xyz/address/0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065), [0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884](https://snowscan.xyz/address/0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884), [0x75C26ED4D9c5D331665766394D933E12f8597a55](https://snowscan.xyz/address/0x75C26ED4D9c5D331665766394D933E12f8597a55), [0xbf113Fa52454A94185b65e6f2E818B7f178f937a](https://snowscan.xyz/address/0xbf113Fa52454A94185b65e6f2E818B7f178f937a), [0x606dC57cd166643760E049609bfd1D8a698D3bAc](https://snowscan.xyz/address/0x606dC57cd166643760E049609bfd1D8a698D3bAc) | |--------|--------|--------|--------|
+
+### Admins
+| Role |Contract |
+|----------|----------|
+|  DEFAULT_ADMIN |  [Executor_lvl1](https://snowscan.xyz/address/0x3C06dce358add17aAf230f2234bCCC4afd50d090) | |--------|--------|
+|  POOL_ADMIN |  [Executor_lvl1](https://snowscan.xyz/address/0x3C06dce358add17aAf230f2234bCCC4afd50d090) | |--------|--------|
+|  EMERGENCY_ADMIN |  [Aave Protocol Guardian Avalanche](https://snowscan.xyz/address/0x56C1a4b54921DEA9A344967a8693C7E661D72968) | |--------|--------|
+|  ASSET_LISTING_ADMIN |   | |--------|--------|
+|  RISK_ADMIN |  [Proof Of Reserve Executor V3](https://snowscan.xyz/address/0xB94e515615c244Ab25f7A6e592e3Cb7EE31E99F4), [Gho Aave Steward](https://snowscan.xyz/address/0xA5Ba213867E175A182a5dd6A9193C6158738105A), [Manual AGRS](https://snowscan.xyz/address/0x43632469e02CDAaEB4dE3DcBfCAaBEf310975729) | |--------|--------|
+|  FLASH_BORROWER |  [0x14F8e5Fe35b2d0D67dBcE9329f1b5d09f60c06C3](https://snowscan.xyz/address/0x14F8e5Fe35b2d0D67dBcE9329f1b5d09f60c06C3), [0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7](https://snowscan.xyz/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7), [0xdeCC46a4b09162F5369c5C80383AAa9159bCf192](https://snowscan.xyz/address/0xdeCC46a4b09162F5369c5C80383AAa9159bCf192) | |--------|--------|
 
 ### AccessManager Roles
 | Role |Contract |

--- a/out/ETHEREUM-V4.md
+++ b/out/ETHEREUM-V4.md
@@ -22,6 +22,8 @@
 |  [USDG MAPLE ESpoke](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989) |  V4 Security Council | |--------|--------|
 |  [SpokeConfigurator](https://etherscan.io/address/0x9BFFf48BFb5A7AE70c348d4d4cb97E8DEFa5389a) |  not upgradeable | |--------|--------|
 |  [TreasurySpoke](https://etherscan.io/address/0xB9B0b8616f6Bf6841972a52058132BE08d723155) |  V4 Security Council | |--------|--------|
+|  [PoolAddressesProvider](https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e) |  not upgradeable | |--------|--------|
+|  [ACLManager](https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0) |  not upgradeable | |--------|--------|
 
 ### TokenizationSpokes upgradeability
 | contract |upgradeable by |
@@ -61,6 +63,12 @@
 |  [GLOBAL DOLLAR USDC TokenizationSpoke](https://etherscan.io/address/0xaed7c529bD2878170B61C758DfAa215AC7a4FD07) |  V4 Security Council | |--------|--------|
 |  [GLOBAL DOLLAR USDT TokenizationSpoke](https://etherscan.io/address/0xa0e97e45C2f89003730E467Bd484fA3eEcE5B4Cf) |  V4 Security Council | |--------|--------|
 |  [GLOBAL DOLLAR USDG TokenizationSpoke](https://etherscan.io/address/0x378B4a7c394E22bd562F66eB612165893533c124) |  V4 Security Council | |--------|--------|
+
+### Actions type
+| type |can be executed by |
+|----------|----------|
+|  adminsConfiguration |  Governance | |--------|--------|
+|  protocolUpgradeablity |  Governance | |--------|--------|
 
 ### Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |
@@ -104,6 +112,8 @@
 |  [USDG MAPLE ESpoke](https://etherscan.io/address/0x774b9655413c34809c1f1b16b654465A89EBE989) |  [USDG MAPLE ESpoke ProxyAdmin](https://etherscan.io/address/0xc2C9F8158C6d6Ca7C22c72520F2d024b7501aaA6) |  SPOKE_USER_POSITION_UPDATER_ROLE |   |  updateUserDynamicConfig, updateUserRiskPremium | |--------|--------|--------|--------|--------|
 |  [SpokeConfigurator](https://etherscan.io/address/0x9BFFf48BFb5A7AE70c348d4d4cb97E8DEFa5389a) |  - |  SPOKE_CONFIGURATOR_DOMAIN_ADMIN_ROLE |  [V4 Security Council](https://etherscan.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9), [V4 Security Council Executor](https://etherscan.io/address/0x14339e2178A954d5FB839D5Ff31644fE0F25F517), [Executor_lvl1](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) |  updateReservePriceSource, updateLiquidationTargetHealthFactor, updateHealthFactorForMaxBonus, updateLiquidationBonusFactor, updateLiquidationConfig, addReserve, updatePaused, updateFrozen, updateBorrowable, updateReceiveSharesEnabled, updateCollateralRisk, addCollateralFactor, updateCollateralFactor, addMaxLiquidationBonus, updateMaxLiquidationBonus, addLiquidationFee, updateLiquidationFee, addDynamicReserveConfig, updateDynamicReserveConfig, pauseAllReserves, freezeAllReserves, pauseReserve, freezeReserve, updatePositionManager | |--------|--------|--------|--------|--------|
 |  [TreasurySpoke](https://etherscan.io/address/0xB9B0b8616f6Bf6841972a52058132BE08d723155) |  [TreasurySpoke ProxyAdmin](https://etherscan.io/address/0x890B79dDcdCCd663B4D7fC121A7A70184489b505) |  onlyOwner |  [V4 Security Council](https://etherscan.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  supply, supplySkimmed, withdraw, transfer | |--------|--------|--------|--------|--------|
+|  [PoolAddressesProvider](https://etherscan.io/address/0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e) |  - |  onlyOwner |  [Executor_lvl1](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) |  setMarketId, setAddress, setAddressAsProxy, setPoolImpl, setPoolConfiguratorImpl, setPriceOracle, setACLManager, setACLAdmin, setPriceOracleSentinel, setPoolDataProvider | |--------|--------|--------|--------|--------|
+|  [ACLManager](https://etherscan.io/address/0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0) |  - |  onlyRole |  [Executor_lvl1](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) |  setRoleAdmin | |--------|--------|--------|--------|--------|
 
 ### PositionManagers Contracts
 | contract |proxyAdmin |modifier |permission owner |functions |
@@ -134,6 +144,16 @@
 | Guardian |Threshold |Address |Owners |
 |----------|----------|----------|----------|
 |  [V4 Security Council](https://etherscan.io/address/0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9) |  5/8 |  0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9 |  [0x9440850335c7C2a644dc2abEBBA93463c9736F2C](https://etherscan.io/address/0x9440850335c7C2a644dc2abEBBA93463c9736F2C), [0xbf113Fa52454A94185b65e6f2E818B7f178f937a](https://etherscan.io/address/0xbf113Fa52454A94185b65e6f2E818B7f178f937a), [0x75C26ED4D9c5D331665766394D933E12f8597a55](https://etherscan.io/address/0x75C26ED4D9c5D331665766394D933E12f8597a55), [0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884](https://etherscan.io/address/0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884), [0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065](https://etherscan.io/address/0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065), [0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749](https://etherscan.io/address/0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749), [0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF](https://etherscan.io/address/0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF), [0x606dC57cd166643760E049609bfd1D8a698D3bAc](https://etherscan.io/address/0x606dC57cd166643760E049609bfd1D8a698D3bAc) | |--------|--------|--------|--------|
+
+### Admins
+| Role |Contract |
+|----------|----------|
+|  DEFAULT_ADMIN |  [Executor_lvl1](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) | |--------|--------|
+|  POOL_ADMIN |  [Executor_lvl1](https://etherscan.io/address/0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A) | |--------|--------|
+|  EMERGENCY_ADMIN |  [Aave Protocol Guardian Ethereum](https://etherscan.io/address/0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30) | |--------|--------|
+|  FLASH_BORROWER |  [0xd9D8e68717Ce24CCbf162868aaad7E38d81b05d1](https://etherscan.io/address/0xd9D8e68717Ce24CCbf162868aaad7E38d81b05d1), [0x72915D41982DfCAf30b871290618E59C45Edba7F](https://etherscan.io/address/0x72915D41982DfCAf30b871290618E59C45Edba7F), [0x8761e0370f94f68Db8EaA731f4fC581f6AD0Bd68](https://etherscan.io/address/0x8761e0370f94f68Db8EaA731f4fC581f6AD0Bd68), [0xab515542d621574f9b5212d50593cD0C07e641bD](https://etherscan.io/address/0xab515542d621574f9b5212d50593cD0C07e641bD), [0x85105b7E11c442Ca6fF6b4d90d7a439f68376Ac4](https://etherscan.io/address/0x85105b7E11c442Ca6fF6b4d90d7a439f68376Ac4), [0x45c00508C14601fd1C1e296eB3C0e3eEEdCa45D0](https://etherscan.io/address/0x45c00508C14601fd1C1e296eB3C0e3eEEdCa45D0), [0x6e8ac99B2ec2e08600c7d0Aab970f31e9b11957a](https://etherscan.io/address/0x6e8ac99B2ec2e08600c7d0Aab970f31e9b11957a), [0x3a657Ec8a755d2E43DDbfDeaDc15899EDaf8dcf8](https://etherscan.io/address/0x3a657Ec8a755d2E43DDbfDeaDc15899EDaf8dcf8), [0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec](https://etherscan.io/address/0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec), [0x0274a704a6D9129F90A62dDC6f6024b33EcDad36](https://etherscan.io/address/0x0274a704a6D9129F90A62dDC6f6024b33EcDad36), [0x49d9409111a6363d82C4371fFa43fAEA660C917B](https://etherscan.io/address/0x49d9409111a6363d82C4371fFa43fAEA660C917B), [0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7](https://etherscan.io/address/0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7), [0xdeCC46a4b09162F5369c5C80383AAa9159bCf192](https://etherscan.io/address/0xdeCC46a4b09162F5369c5C80383AAa9159bCf192) | |--------|--------|
+|  RISK_ADMIN |  [Core GHO Aave Steward](https://etherscan.io/address/0x98217A06721Ebf727f2C8d9aD7718ec28b7aAe34), [Gho Core Direct Minter](https://etherscan.io/address/0x5513224daaEABCa31af5280727878d52097afA05), [Manual AGRS](https://etherscan.io/address/0x13a9CC64344b02bACC5AD9Cf38B5711F1B9ec3d4), [PendleDiscountRateAgent](https://etherscan.io/address/0x529e2374afB38AC465D71979E7540ad93C05F6c5), [EModeCategoryAgent](https://etherscan.io/address/0xbe2840440d4f77CD98CEC2de09913e6851907744) | |--------|--------|
+|  ASSET_LISTING_ADMIN |   | |--------|--------|
 
 ### AccessManager Roles
 | Role |Contract |

--- a/out/permissions/1-permissions.json
+++ b/out/permissions/1-permissions.json
@@ -11276,9 +11276,89 @@
             "functions": []
           }
         ]
+      },
+      "PoolAddressesProvider": {
+        "address": "0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e",
+        "modifiers": [
+          {
+            "modifier": "onlyOwner",
+            "addresses": [
+              {
+                "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+                "owners": [],
+                "signersThreshold": 0
+              }
+            ],
+            "functions": [
+              "setMarketId",
+              "setAddress",
+              "setAddressAsProxy",
+              "setPoolImpl",
+              "setPoolConfiguratorImpl",
+              "setPriceOracle",
+              "setACLManager",
+              "setACLAdmin",
+              "setPriceOracleSentinel",
+              "setPoolDataProvider"
+            ]
+          }
+        ]
+      },
+      "ACLManager": {
+        "address": "0xc2aaCf6553D20d1e9d78E365AAba8032af9c85b0",
+        "modifiers": [
+          {
+            "modifier": "onlyRole",
+            "addresses": [
+              {
+                "address": "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A",
+                "owners": [],
+                "signersThreshold": 0
+              }
+            ],
+            "functions": [
+              "setRoleAdmin"
+            ]
+          }
+        ]
       }
     },
-    "roles": {},
+    "roles": {
+      "role": {
+        "DEFAULT_ADMIN": [
+          "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A"
+        ],
+        "POOL_ADMIN": [
+          "0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A"
+        ],
+        "EMERGENCY_ADMIN": [
+          "0x2CFe3ec4d5a6811f4B8067F0DE7e47DfA938Aa30"
+        ],
+        "FLASH_BORROWER": [
+          "0xd9D8e68717Ce24CCbf162868aaad7E38d81b05d1",
+          "0x72915D41982DfCAf30b871290618E59C45Edba7F",
+          "0x8761e0370f94f68Db8EaA731f4fC581f6AD0Bd68",
+          "0xab515542d621574f9b5212d50593cD0C07e641bD",
+          "0x85105b7E11c442Ca6fF6b4d90d7a439f68376Ac4",
+          "0x45c00508C14601fd1C1e296eB3C0e3eEEdCa45D0",
+          "0x6e8ac99B2ec2e08600c7d0Aab970f31e9b11957a",
+          "0x3a657Ec8a755d2E43DDbfDeaDc15899EDaf8dcf8",
+          "0xb5b29320d2Dde5BA5BAFA1EbcD270052070483ec",
+          "0x0274a704a6D9129F90A62dDC6f6024b33EcDad36",
+          "0x49d9409111a6363d82C4371fFa43fAEA660C917B",
+          "0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7",
+          "0xdeCC46a4b09162F5369c5C80383AAa9159bCf192"
+        ],
+        "RISK_ADMIN": [
+          "0x98217A06721Ebf727f2C8d9aD7718ec28b7aAe34",
+          "0x5513224daaEABCa31af5280727878d52097afA05",
+          "0x13a9CC64344b02bACC5AD9Cf38B5711F1B9ec3d4",
+          "0x529e2374afB38AC465D71979E7540ad93C05F6c5",
+          "0xbe2840440d4f77CD98CEC2de09913e6851907744"
+        ],
+        "ASSET_LISTING_ADMIN": []
+      }
+    },
     "gsmRoles": {},
     "govV3": {
       "ggRoles": {}

--- a/out/permissions/43114-permissions.json
+++ b/out/permissions/43114-permissions.json
@@ -3658,9 +3658,77 @@
             "functions": []
           }
         ]
+      },
+      "PoolAddressesProvider": {
+        "address": "0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb",
+        "modifiers": [
+          {
+            "modifier": "onlyOwner",
+            "addresses": [
+              {
+                "address": "0x3C06dce358add17aAf230f2234bCCC4afd50d090",
+                "owners": [],
+                "signersThreshold": 0
+              }
+            ],
+            "functions": [
+              "setMarketId",
+              "setAddress",
+              "setAddressAsProxy",
+              "setPoolImpl",
+              "setPoolConfiguratorImpl",
+              "setPriceOracle",
+              "setACLManager",
+              "setACLAdmin",
+              "setPriceOracleSentinel",
+              "setPoolDataProvider"
+            ]
+          }
+        ]
+      },
+      "ACLManager": {
+        "address": "0xa72636CbcAa8F5FF95B2cc47F3CDEe83F3294a0B",
+        "modifiers": [
+          {
+            "modifier": "onlyRole",
+            "addresses": [
+              {
+                "address": "0x3C06dce358add17aAf230f2234bCCC4afd50d090",
+                "owners": [],
+                "signersThreshold": 0
+              }
+            ],
+            "functions": [
+              "setRoleAdmin"
+            ]
+          }
+        ]
       }
     },
-    "roles": {},
+    "roles": {
+      "role": {
+        "DEFAULT_ADMIN": [
+          "0x3C06dce358add17aAf230f2234bCCC4afd50d090"
+        ],
+        "POOL_ADMIN": [
+          "0x3C06dce358add17aAf230f2234bCCC4afd50d090"
+        ],
+        "EMERGENCY_ADMIN": [
+          "0x56C1a4b54921DEA9A344967a8693C7E661D72968"
+        ],
+        "ASSET_LISTING_ADMIN": [],
+        "RISK_ADMIN": [
+          "0xB94e515615c244Ab25f7A6e592e3Cb7EE31E99F4",
+          "0xA5Ba213867E175A182a5dd6A9193C6158738105A",
+          "0x43632469e02CDAaEB4dE3DcBfCAaBEf310975729"
+        ],
+        "FLASH_BORROWER": [
+          "0x14F8e5Fe35b2d0D67dBcE9329f1b5d09f60c06C3",
+          "0x352423e2fA5D5c99343d371C9e3bC56C87723Cc7",
+          "0xdeCC46a4b09162F5369c5C80383AAa9159bCf192"
+        ]
+      }
+    },
     "gsmRoles": {},
     "govV3": {
       "ggRoles": {}

--- a/out/permissions/5042-permissions.json
+++ b/out/permissions/5042-permissions.json
@@ -416,9 +416,83 @@
             "functions": []
           }
         ]
+      },
+      "PoolAddressesProvider": {
+        "address": "0xf74284E5aeDC3AD57CD2Fa2461bf2E1762422a12",
+        "modifiers": [
+          {
+            "modifier": "onlyOwner",
+            "addresses": [
+              {
+                "address": "0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9",
+                "owners": [
+                  "0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF",
+                  "0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749",
+                  "0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065",
+                  "0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884",
+                  "0x75C26ED4D9c5D331665766394D933E12f8597a55",
+                  "0x9440850335c7C2a644dc2abEBBA93463c9736F2C",
+                  "0xbf113Fa52454A94185b65e6f2E818B7f178f937a",
+                  "0x606dC57cd166643760E049609bfd1D8a698D3bAc"
+                ],
+                "signersThreshold": 5
+              }
+            ],
+            "functions": [
+              "setMarketId",
+              "setAddress",
+              "setAddressAsProxy",
+              "setPoolImpl",
+              "setPoolConfiguratorImpl",
+              "setPriceOracle",
+              "setACLManager",
+              "setACLAdmin",
+              "setPriceOracleSentinel",
+              "setPoolDataProvider"
+            ]
+          }
+        ]
+      },
+      "ACLManager": {
+        "address": "0x4d4B307857eFff79E786923F2A277ea298E88aEA",
+        "modifiers": [
+          {
+            "modifier": "onlyRole",
+            "addresses": [
+              {
+                "address": "0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9",
+                "owners": [
+                  "0x76c82c2cB7C5dB3B053A251F3281081C6EC40FDF",
+                  "0x9AB4e51a7cd8cE1279D9dbfA01Ad61367C3e3749",
+                  "0xc0A15667D6c63ac2CBFCAf5ABbFA0639018B2065",
+                  "0x437B97618dFB8c8B1f403Bd2E9436730f0f9D884",
+                  "0x75C26ED4D9c5D331665766394D933E12f8597a55",
+                  "0x9440850335c7C2a644dc2abEBBA93463c9736F2C",
+                  "0xbf113Fa52454A94185b65e6f2E818B7f178f937a",
+                  "0x606dC57cd166643760E049609bfd1D8a698D3bAc"
+                ],
+                "signersThreshold": 5
+              }
+            ],
+            "functions": [
+              "setRoleAdmin"
+            ]
+          }
+        ]
       }
     },
-    "roles": {},
+    "roles": {
+      "role": {
+        "DEFAULT_ADMIN": [
+          "0x187AAE17d4931310B3fc75743e7F16Bdc9eD77e9"
+        ],
+        "ASSET_LISTING_ADMIN": [],
+        "EMERGENCY_ADMIN": [],
+        "FLASH_BORROWER": [],
+        "POOL_ADMIN": [],
+        "RISK_ADMIN": []
+      }
+    },
     "gsmRoles": {},
     "govV3": {
       "ggRoles": {}

--- a/out/permissions/metadata/1-metadata.json
+++ b/out/permissions/metadata/1-metadata.json
@@ -150,7 +150,7 @@
     }
   },
   "V4": {
-    "latestBlockNumber": 25936162,
+    "latestBlockNumber": 25939898,
     "indexedContracts": {
       "ACCESS_MANAGER": {
         "address": "0x08aE3BE30958cDd1847ec58fFfd4C451a87fDF01",
@@ -160,7 +160,7 @@
     }
   },
   "V4_SPOKE_PM": {
-    "latestBlockNumber": 25936162,
+    "latestBlockNumber": 25939898,
     "indexedContracts": {
       "0x7320cf22ac095ba2a2e0a652f77efb836c2e751b": {
         "address": "0x7320cf22ac095ba2a2e0a652f77efb836c2e751b",

--- a/out/permissions/metadata/43114-metadata.json
+++ b/out/permissions/metadata/43114-metadata.json
@@ -70,7 +70,7 @@
     }
   },
   "V4": {
-    "latestBlockNumber": 94812516,
+    "latestBlockNumber": 94855949,
     "indexedContracts": {
       "ACCESS_MANAGER": {
         "address": "0xe069096bDAfF9bAD15b2f1079EaF0f1685a24522",
@@ -80,7 +80,7 @@
     }
   },
   "V4_SPOKE_PM": {
-    "latestBlockNumber": 94812516,
+    "latestBlockNumber": 94855949,
     "indexedContracts": {
       "0x1604d602f8a05cba2d8ff5d14de4c3498f15b6b4": {
         "address": "0x1604d602f8a05cba2d8ff5d14de4c3498f15b6b4",

--- a/out/permissions/metadata/5042-metadata.json
+++ b/out/permissions/metadata/5042-metadata.json
@@ -1,16 +1,21 @@
 {
   "V4": {
-    "latestBlockNumber": 19967402,
+    "latestBlockNumber": 19969999,
     "indexedContracts": {
       "ACCESS_MANAGER": {
         "address": "0x24761DB265998ba1D38E8a29031cF72C2CeF3A7D",
         "deploymentBlock": 18791458,
         "firstIndexedAt": 18791458
+      },
+      "ACL_MANAGER": {
+        "address": "0x4d4B307857eFff79E786923F2A277ea298E88aEA",
+        "deploymentBlock": 17408596,
+        "firstIndexedAt": 17408596
       }
     }
   },
   "V4_SPOKE_PM": {
-    "latestBlockNumber": 19967402,
+    "latestBlockNumber": 19969999,
     "indexedContracts": {
       "0x42eab64310e1d1c66b4d8af7c9c4ce253885eb83": {
         "address": "0x42eab64310e1d1c66b4d8af7c9c4ce253885eb83",

--- a/scripts/createTables.ts
+++ b/scripts/createTables.ts
@@ -153,8 +153,20 @@ const buildActionPoolInfo = (
   const isV4 = pool === Pools.V4;
 
   if (isV4) {
+    // A shared ACLManager/PoolAddressesProvider is administered by a governance
+    // executor, which lives in V3's governance section rather than in the V4
+    // pool, so the classifier needs it to resolve the action to Governance.
+    // Only the executors are merged: the other governance contracts would add
+    // V3 governance actions (adi, proposals) the V4 market does not have.
+    const v3GovExecutors = Object.fromEntries(
+      Object.entries(networkPermits['V3']?.govV3?.contracts ?? {}).filter(
+        ([contractName]) => contractName.startsWith('Executor'),
+      ),
+    );
+
     return {
       ...currentPoolContracts,
+      ...v3GovExecutors,
       ...networkPermits[Pools.V4]?.govV3?.contracts,
     } as Contracts;
   }

--- a/scripts/modifiersCalculator.ts
+++ b/scripts/modifiersCalculator.ts
@@ -56,6 +56,7 @@ import { resolveGovV3Modifiers } from './govV3Permissions.js';
 import { resolveGHOModifiers } from './ghoPermissions.js';
 import {
   resolveV4Modifiers,
+  resolveV4AclModifiers,
   resolveTokenizationSpokeUpgradeability,
   resolveV4PositionManagerModifiers,
   getTrackedV4Addresses,
@@ -490,6 +491,53 @@ const generateNetworkPermissions = async (
           roles: v4Roles,
           functionRoles: v4FunctionRoles,
           roleLabels: v4Result.roleLabels,
+        };
+      }
+
+      // A V4 market can also have a V3-style ACLManager + PoolAddressesProvider
+      // backing its periphery. Those sit outside the AccessManager graph, so
+      // their roles come from ACL RoleGranted/RoleRevoked events.
+      //
+      // Arc has no V3 market and deploys its own pair, indexed here. Where the
+      // network does have a V3 market, the V4 pool points at that market's ACL
+      // manager, so the roles the V3 pool already indexed are reused instead of
+      // replaying the same contract's full history a second time.
+      if (pool.addressBook.ACL_MANAGER) {
+        const v3AclManager = pools[Pools.V3]?.addressBook?.ACL_MANAGER as string | undefined;
+        const sharedWithV3 =
+          !!v3AclManager &&
+          getAddress(v3AclManager) === getAddress(pool.addressBook.ACL_MANAGER as string);
+
+        let aclRoles: Record<string, string[]>;
+        if (sharedWithV3) {
+          logTableGeneration(network, poolKey, 'ACL Manager (shared with V3)');
+          aclRoles = fullJson[Pools.V3]?.roles?.role || {};
+        } else {
+          if (!pool.aclBlock) {
+            throw new Error(
+              `${poolKey} on network ${network} has an ACL_MANAGER that no V3 pool shares, but no aclBlock to index it from`,
+            );
+          }
+          logTableGeneration(network, poolKey, 'ACL Manager', indexedLatestBlock || pool.aclBlock);
+          aclRoles = getRoleAdmins({
+            oldRoles: (fullJson[poolKey]?.roles?.role) || {},
+            roleNames: protocolRoleNames,
+            eventLogs: indexedEvents['ACL_MANAGER'] || [],
+          });
+        }
+
+        admins = {
+          role: aclRoles,
+        };
+
+        poolPermissions = {
+          ...poolPermissions,
+          ...(await resolveV4AclModifiers(
+            pool.addressBook,
+            poolProvider,
+            permissionsJson,
+            admins.role,
+          )),
         };
       }
     } else if (

--- a/scripts/v4Permissions.ts
+++ b/scripts/v4Permissions.ts
@@ -2,8 +2,11 @@ import { Address, Client, getAddress, getContract, toFunctionSelector } from 'vi
 import { onlyOwnerAbi } from '../abis/onlyOwnerAbi.js';
 import { accessManagerAbi } from '../abis/accessManagerAbi.js';
 import { rescuableAbi } from '../abis/rescuableAbi.js';
+import { poolAddressProviderAbi } from '../abis/lendingPoolAddressProviderAbi.js';
 import { getProxyAdmin } from '../helpers/proxyAdmin.js';
 import { createOwnerResolver } from '../helpers/ownerResolver.js';
+import { generateRoles } from '../helpers/jsonParsers.js';
+import { mapRoleAddresses } from '../helpers/contractResolvers.js';
 import {
   AddressBook,
   Contracts,
@@ -442,6 +445,67 @@ export const resolveV4Modifiers = async (
   }
 
   return { contracts: obj, roleLabels };
+};
+
+/**
+ * Resolves the V3-style PoolAddressesProvider and ACLManager that back a V4
+ * market's periphery access control. They sit outside the AccessManager graph,
+ * so permissions come from `owner()` and the ACL manager's DEFAULT_ADMIN
+ * holders instead of function role mappings.
+ */
+export const resolveV4AclModifiers = async (
+  addressBook: AddressBook,
+  provider: Client,
+  permissionsObject: PermissionsJson,
+  adminRoles: Record<string, string[]>,
+): Promise<Contracts> => {
+  const obj: Contracts = {};
+  const roles = generateRoles(permissionsObject);
+  const ownerResolver = createOwnerResolver(provider);
+
+  if (addressBook.POOL_ADDRESSES_PROVIDER) {
+    const addressesProvider = getContract({
+      address: getAddress(addressBook.POOL_ADDRESSES_PROVIDER as string),
+      abi: poolAddressProviderAbi,
+      client: provider,
+    });
+    const owner = (await addressesProvider.read.owner()) as Address;
+    const ownerInfo = await ownerResolver.resolve(owner);
+
+    obj['PoolAddressesProvider'] = {
+      address: addressBook.POOL_ADDRESSES_PROVIDER as string,
+      modifiers: [
+        {
+          modifier: 'onlyOwner',
+          addresses: [
+            {
+              address: owner,
+              owners: ownerInfo.owners,
+              signersThreshold: ownerInfo.threshold,
+            },
+          ],
+          functions: roles['PoolAddressesProvider']['onlyOwner'],
+        },
+      ],
+    };
+  }
+
+  if (addressBook.ACL_MANAGER) {
+    const roleOwners = await ownerResolver.resolveRoleOwners(adminRoles);
+
+    obj['ACLManager'] = {
+      address: addressBook.ACL_MANAGER as string,
+      modifiers: [
+        {
+          modifier: 'onlyRole',
+          addresses: mapRoleAddresses('DEFAULT_ADMIN', adminRoles, roleOwners),
+          functions: roles['ACLManager']['onlyRole'],
+        },
+      ],
+    };
+  }
+
+  return obj;
 };
 
 /**

--- a/statics/functionsPermissionsV4.json
+++ b/statics/functionsPermissionsV4.json
@@ -446,5 +446,60 @@
         "roles": ["onlyRescueGuardian"]
       }
     ]
+  },
+  {
+    "contract": "PoolAddressesProvider",
+    "proxyAdmin": false,
+    "functions": [
+      {
+        "name": "setMarketId",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setAddress",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setAddressAsProxy",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setPoolImpl",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setPoolConfiguratorImpl",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setPriceOracle",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setACLManager",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setACLAdmin",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setPriceOracleSentinel",
+        "roles": ["onlyOwner"]
+      },
+      {
+        "name": "setPoolDataProvider",
+        "roles": ["onlyOwner"]
+      }
+    ]
+  },
+  {
+    "contract": "ACLManager",
+    "functions": [
+      {
+        "name": "setRoleAdmin",
+        "roles": ["onlyRole"]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Follow-up to #195. Adds the V3-style `ACLManager` and `PoolAddressesProvider` that back a V4 market's periphery access control to the V4 pages of all three V4 networks.

Both contracts sit outside the AccessManager graph, so `resolveV4AclModifiers` reads `owner()` on the provider and maps the ACL manager's `DEFAULT_ADMIN` holders, rather than going through function role mappings.

## Per network

| Network | ACLManager | PoolAddressesProvider | Roles from |
|---|---|---|---|
| Arc | `0x4d4B3078…` (`MiscArc`) | `0xf74284E5…` (`MiscArc`) | own events, `aclBlock: 17408596` |
| Ethereum | `0xc2aaCf65…` (`AaveV3Ethereum`) | `0x2f39d218…` (`AaveV3Ethereum`) | V3 pool |
| Avalanche | `0xa72636Cb…` (`AaveV3Avalanche`) | `0xa97684ea…` (`AaveV3Avalanche`) | V3 pool |

Arc has no V3 market, so its periphery needed a standalone ACL root: a dedicated pair deployed at blocks 17408589 and 17408596, owned by the V4 Security Council, with `DEFAULT_ADMIN` its only granted role. Ethereum and Avalanche already have that root from their V3 markets, so their V4 pools point at it.

Where the ACL manager is shared, the roles the V3 pool already indexed are reused instead of replaying the same contract's history a second time under the V4 pool. That scan would cost roughly 965 `getLogs` ranges on Ethereum (block 16291117 to head) and 8290 on Avalanche (11970456 to head). A V4 pool whose ACL manager no V3 pool shares must supply `aclBlock`, or generation fails with that message, so a future dedicated deployment cannot silently inherit another market's roles.

## Action classifier

`buildActionPoolInfo`'s V4 branch now also merges V3's governance executors. Without them the two new action rows read `External Contract`, because `checkOwnership` only reaches the governance check for addresses present in `poolInfo`, and the executor administering a shared ACL manager lives in V3's governance section. `buildActionGovInfo` already merged V3 governance for V4. Only the executors are merged: merging all of V3's governance contracts adds `adiConfigurations`, `retryAndInvalidateMessages`, `configureGovernance` and `cancelProposal` rows that describe the network's governance stack rather than the V4 market.

Resulting rows, the only ones any V4 page has:

| Network | adminsConfiguration | protocolUpgradeablity |
|---|---|---|
| Ethereum, Avalanche | Governance | Governance |
| Arc | Multi-sig | Multi-sig |

`protocolUpgradeablity` reads stronger than reality on Arc, where the provider has no Pool, PoolConfigurator or oracle registered yet: `getPool()`, `getPoolConfigurator()`, `getPriceOracle()` and `getACLManager()` all still return zero.

## Verification

- `tsc --noEmit` error set is identical to main's (the repo does not typecheck clean at HEAD, so the comparison is against that baseline).
- Every permissions JSON change is additive. The only removed line per file is the empty `"roles": {}`.
- The V4 `roles` sections on Ethereum and Avalanche match their V3 sections exactly, and both V4 pools resolve the same ACL manager address as their V3 pool.
- Other V4 networks are unaffected by the statics change: `PoolAddressesProvider` and `ACLManager` only render for pools whose address book carries those keys.